### PR TITLE
injection: Substitute rmmod with modprobe -r.

### DIFF
--- a/injection/setup_inject.sh
+++ b/injection/setup_inject.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/sudo /bin/bash
-rmmod iwlwifi mac80211 cfg80211
+modprobe -r iwlwifi mac80211 cfg80211
 modprobe iwlwifi debug=0x40000
 ifconfig wlan0 2>/dev/null 1>/dev/null
 while [ $? -ne 0 ]

--- a/injection/setup_monitor_csi.sh
+++ b/injection/setup_monitor_csi.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/sudo /bin/bash
-rmmod iwlwifi mac80211 cfg80211
+modprobe -r iwlwifi mac80211 cfg80211
 modprobe iwlwifi connector_log=0x1
 # Setup monitor mode, loop until it works
 iwconfig wlan0 mode monitor 2>/dev/null 1>/dev/null


### PR DESCRIPTION
modprobe -r is a more modern alternative for rmmod. The main difference is that modprobe -r takes dependencies into consideration as well.